### PR TITLE
Fix crashes caused by favtools

### DIFF
--- a/src/redux/slice/drawcontrol.ts
+++ b/src/redux/slice/drawcontrol.ts
@@ -55,7 +55,7 @@ const drawControlSlice = createSlice({
             const index = action.payload as number
             const tool: Tool = {
                 type: state.liveStroke.type,
-                style: state.liveStroke.style,
+                style: { ...state.liveStroke.style },
             }
 
             // validate tool candidate
@@ -73,7 +73,7 @@ const drawControlSlice = createSlice({
         ADD_FAV_TOOL: (state) => {
             const tool: Tool = {
                 type: state.liveStroke.type,
-                style: state.liveStroke.style,
+                style: { ...state.liveStroke.style },
             }
 
             // validate tool candidate
@@ -86,8 +86,11 @@ const drawControlSlice = createSlice({
         },
         SET_TOOL: (state, action) => {
             const { type, style } = action.payload
+            state.liveStroke.style = { ...style }
             state.liveStroke.type = type
-            state.liveStroke.style = style
+            state.isDraggable = type === ToolType.Select
+            state.isListening = type === ToolType.Eraser
+            state.trNodes = []
         },
         SET_COLOR: (state, action) => {
             const color = action.payload


### PR DESCRIPTION
Fix crash caused by not using deep copies when adding / replacing favtools
Fix bug caused by not fully applying the tooltype functionality when using a favtool after an eraser