### PR TITLE
Add custom icon SVGs for all ToolTypes

### DIFF
--- a/src/components/icons/circle.svg
+++ b/src/components/icons/circle.svg
@@ -1,0 +1,10 @@
+<svg
+    stroke="white"
+    stroke-width="8"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
+    viewBox="0 0 100 100">
+    <circle cx="50" cy="50" r="40" />
+</svg>

--- a/src/components/icons/eraser.svg
+++ b/src/components/icons/eraser.svg
@@ -1,0 +1,17 @@
+<svg
+    stroke-width="8"
+    stroke-linejoin="round"
+    stroke-linecap="round"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
+    viewBox="0 0 100 100">
+    <path d="M5,65 
+            L65,5 
+            L95,35 
+            L35,95 
+            z" />
+    <path d="M25,45 
+            L55,75" />
+</svg>

--- a/src/components/icons/index.styled.ts
+++ b/src/components/icons/index.styled.ts
@@ -1,0 +1,35 @@
+import styled, { css } from "styled-components"
+import { ReactComponent as Eraser } from "./eraser.svg"
+import { ReactComponent as Pen } from "./pen.svg"
+import { ReactComponent as Select } from "./select.svg"
+import { ReactComponent as Line } from "./line.svg"
+import { ReactComponent as Circle } from "./circle.svg"
+import { ReactComponent as Square } from "./square.svg"
+
+const iconStyles = css`
+    height: 100%;
+    width: 100%;
+    &:hover {
+        stroke: black;
+    }
+    /* margin: auto; */
+`
+
+export const StyledEraser = styled(Eraser)`
+    ${iconStyles}
+`
+export const StyledPen = styled(Pen)`
+    ${iconStyles}
+`
+export const StyledSelect = styled(Select)`
+    ${iconStyles}
+`
+export const StyledLine = styled(Line)`
+    ${iconStyles}
+`
+export const StyledCircle = styled(Circle)`
+    ${iconStyles}
+`
+export const StyledSquare = styled(Square)`
+    ${iconStyles}
+`

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import {
+    StyledCircle,
+    StyledEraser,
+    StyledLine,
+    StyledPen,
+    StyledSelect,
+    StyledSquare,
+} from "./index.styled"
+
+export interface ToolIconProps {
+    stroke?: string
+}
+export const EraserIcon: React.FC<ToolIconProps> = ({ stroke = "white" }) => (
+    <StyledEraser stroke={stroke} />
+)
+export const PenIcon: React.FC<ToolIconProps> = ({ stroke = "white" }) => (
+    <StyledPen stroke={stroke} />
+)
+export const SelectIcon: React.FC<ToolIconProps> = ({ stroke = "white" }) => (
+    <StyledSelect stroke={stroke} />
+)
+export const LineIcon: React.FC<ToolIconProps> = ({ stroke = "white" }) => (
+    <StyledLine stroke={stroke} />
+)
+export const CircleIcon: React.FC<ToolIconProps> = ({ stroke = "white" }) => (
+    <StyledCircle stroke={stroke} />
+)
+export const SquareIcon: React.FC<ToolIconProps> = ({ stroke = "white" }) => (
+    <StyledSquare stroke={stroke} />
+)

--- a/src/components/icons/line.svg
+++ b/src/components/icons/line.svg
@@ -1,0 +1,12 @@
+<svg
+    stroke="white"
+    stroke-width="8"
+    stroke-linejoin="round"
+    stroke-linecap="round"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
+    viewBox="0 0 100 100">
+    <line x1="10" y1="90" x2="90" y2="10" />
+</svg>

--- a/src/components/icons/pen.svg
+++ b/src/components/icons/pen.svg
@@ -1,0 +1,20 @@
+<svg
+    stroke-width="8"
+    stroke-linejoin="round"
+    stroke-linecap="round"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
+    viewBox="0 0 100 100">
+    <path d="M10,90 
+            L15,55
+            L65,5 
+            L95,35 
+            L45,85 
+            z" />
+    <path d="M50,20 
+            L80,50" />
+    <path d="M15,55 
+            L45,85" />
+</svg>

--- a/src/components/icons/select.svg
+++ b/src/components/icons/select.svg
@@ -1,0 +1,21 @@
+<svg
+    stroke="white"
+    stroke-width="8"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
+    viewBox="0 0 100 100">
+    <g>
+        <path d="M28,16 L72,16" />
+        <path d="M28,84 L72,84" />
+        <path d="M16,28 L16,72" />
+        <path d="M84,28 L84,72" />
+    </g>
+    <g>
+        <rect x="4" y="4" rx="5" ry="5" width="24" height="24" />
+        <rect x="4" y="72" rx="5" ry="5" width="24" height="24" />
+        <rect x="72" y="4" rx="5" ry="5" width="24" height="24" />
+        <rect x="72" y="72" rx="5" ry="5" width="24" height="24" />
+    </g>
+</svg>

--- a/src/components/icons/square.svg
+++ b/src/components/icons/square.svg
@@ -1,0 +1,10 @@
+<svg
+    stroke="white"
+    stroke-width="8"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
+    viewBox="0 0 100 100">
+    <rect x="10" y="10" rx="5" ry="5" width="80" height="80" />
+</svg>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
-export { default as Button } from "./button/button"
 export { default as IconButton } from "./iconbutton/iconbutton"
+export * from "./icons/index"
+export { default as Button } from "./button/button"
 export { default as Popup } from "./popup/popup"
 export { default as TextField } from "./textfield/textfield"
 export { default as Dialog } from "./dialog/dialog"

--- a/src/menu/toolbar/pentool/pentool.tsx
+++ b/src/menu/toolbar/pentool/pentool.tsx
@@ -1,7 +1,13 @@
-import { IconButton, Popup } from "components"
+import {
+    CircleIcon,
+    IconButton,
+    LineIcon,
+    PenIcon,
+    Popup,
+    SquareIcon,
+    ToolIconProps,
+} from "components"
 import React, { useState } from "react"
-import { BsPencil } from "react-icons/bs"
-import { FiMinus, FiCircle, FiSquare } from "react-icons/fi"
 import { useCustomSelector } from "redux/hooks"
 import { SET_TYPE } from "redux/slice/drawcontrol"
 import store from "redux/store"
@@ -16,43 +22,39 @@ const PenTool: React.FC = () => {
     const colorSelector = useCustomSelector(
         (state) => state.drawControl.liveStroke.style.color
     )
-
-    let icon
-    switch (typeSelector) {
-        case ToolType.Pen:
-            icon = <BsPencil id="icon" />
-            break
-        case ToolType.Line:
-            icon = <FiMinus id="icon" />
-            break
-        case ToolType.Rectangle:
-            icon = <FiSquare id="icon" />
-            break
-        case ToolType.Circle:
-            icon = <FiCircle id="icon" />
-            break
-        default:
-            icon = <BsPencil id="icon" />
-            break
-    }
-
     const isDrawingTool = () =>
         typeSelector === ToolType.Pen ||
         typeSelector === ToolType.Line ||
         typeSelector === ToolType.Rectangle ||
         typeSelector === ToolType.Circle
 
+    const IconX: React.FC<ToolIconProps> = (props) => {
+        switch (typeSelector) {
+            case ToolType.Pen:
+                return <PenIcon {...props} />
+            case ToolType.Line:
+                return <LineIcon {...props} />
+            case ToolType.Rectangle:
+                return <SquareIcon {...props} />
+            case ToolType.Circle:
+                return <CircleIcon {...props} />
+            default:
+                return <PenIcon {...props} />
+        }
+    }
+
     return (
         <>
-            <IconButton
-                style={isDrawingTool() ? { color: colorSelector } : {}}
-                onClick={
-                    isDrawingTool()
-                        ? () => setOpen(true)
-                        : () => store.dispatch(SET_TYPE(ToolType.Pen))
-                }>
-                {icon}
-            </IconButton>
+            {isDrawingTool() ? (
+                <IconButton onClick={() => setOpen(true)}>
+                    <IconX stroke={colorSelector} />
+                </IconButton>
+            ) : (
+                <IconButton
+                    onClick={() => store.dispatch(SET_TYPE(ToolType.Pen))}>
+                    <IconX />
+                </IconButton>
+            )}
             <Popup open={open} onClose={() => setOpen(false)}>
                 <StylePicker />
             </Popup>

--- a/src/menu/toolbar/stylepicker/shapetools/shapetools.tsx
+++ b/src/menu/toolbar/stylepicker/shapetools/shapetools.tsx
@@ -1,8 +1,12 @@
 import React from "react"
-import { FiMinus, FiCircle, FiSquare } from "react-icons/fi"
-import { BsPencil } from "react-icons/bs"
 import { useCustomSelector } from "redux/hooks"
-import { IconButton } from "components"
+import {
+    CircleIcon,
+    IconButton,
+    LineIcon,
+    PenIcon,
+    SquareIcon,
+} from "components"
 import { SET_TYPE } from "redux/slice/drawcontrol"
 import store from "redux/store"
 import { ToolType } from "types"
@@ -18,48 +22,52 @@ const ShapeTools: React.FC = () => {
     return (
         <StyledShapeTools>
             <IconButton
-                style={
-                    typeSelector === ToolType.Pen
-                        ? { color: colorSelector }
-                        : {}
-                }
                 onClick={() => {
                     store.dispatch(SET_TYPE(ToolType.Pen))
                 }}>
-                <BsPencil id="icon" />
+                <PenIcon
+                    stroke={
+                        typeSelector === ToolType.Pen
+                            ? colorSelector
+                            : undefined
+                    }
+                />
             </IconButton>
             <IconButton
-                style={
-                    typeSelector === ToolType.Line
-                        ? { color: colorSelector }
-                        : {}
-                }
                 onClick={() => {
                     store.dispatch(SET_TYPE(ToolType.Line))
                 }}>
-                <FiMinus id="icon" />
+                <LineIcon
+                    stroke={
+                        typeSelector === ToolType.Line
+                            ? colorSelector
+                            : undefined
+                    }
+                />
             </IconButton>
             <IconButton
-                style={
-                    typeSelector === ToolType.Rectangle
-                        ? { color: colorSelector }
-                        : {}
-                }
                 onClick={() => {
                     store.dispatch(SET_TYPE(ToolType.Rectangle))
                 }}>
-                <FiSquare id="icon" />
+                <SquareIcon
+                    stroke={
+                        typeSelector === ToolType.Rectangle
+                            ? colorSelector
+                            : undefined
+                    }
+                />
             </IconButton>
             <IconButton
-                style={
-                    typeSelector === ToolType.Circle
-                        ? { color: colorSelector }
-                        : {}
-                }
                 onClick={() => {
                     store.dispatch(SET_TYPE(ToolType.Circle))
                 }}>
-                <FiCircle id="icon" />
+                <CircleIcon
+                    stroke={
+                        typeSelector === ToolType.Circle
+                            ? colorSelector
+                            : undefined
+                    }
+                />
             </IconButton>
         </StyledShapeTools>
     )

--- a/src/menu/toolbar/toolring/toolring.tsx
+++ b/src/menu/toolbar/toolring/toolring.tsx
@@ -1,10 +1,9 @@
 import React from "react"
-import { CgErase } from "react-icons/cg"
-import { BiSelection } from "react-icons/bi"
 import { useCustomSelector } from "redux/hooks"
-import { IconButton } from "components"
+import { EraserIcon, IconButton, SelectIcon } from "components"
 import store from "redux/store"
 import { SET_TYPE } from "redux/slice/drawcontrol"
+
 import PenTool from "../pentool/pentool"
 import { ToolType } from "../../../types"
 
@@ -17,18 +16,24 @@ const ToolRing: React.FC = () => {
         <>
             <PenTool />
             <IconButton
-                active={typeSelector === ToolType.Eraser}
                 onClick={() => {
                     store.dispatch(SET_TYPE(ToolType.Eraser))
                 }}>
-                <CgErase id="icon" />
+                <EraserIcon
+                    stroke={
+                        typeSelector === ToolType.Eraser ? "black" : undefined
+                    }
+                />
             </IconButton>
             <IconButton
-                active={typeSelector === ToolType.Select}
                 onClick={() => {
                     store.dispatch(SET_TYPE(ToolType.Select))
                 }}>
-                <BiSelection id="icon" />
+                <SelectIcon
+                    stroke={
+                        typeSelector === ToolType.Select ? "black" : undefined
+                    }
+                />
             </IconButton>
         </>
     )


### PR DESCRIPTION
Add custom icon SVGs for all ToolTypes
Replace old with new custom icons
Add stroke customisation

<table>
  <tr>
    <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td align="middle"><img src="https://user-images.githubusercontent.com/18195396/132590096-41154011-f311-49d1-82ee-6b1f802eaa71.png" width="50%"></td>
    <td align="middle"><img src="https://user-images.githubusercontent.com/18195396/132589826-815fea17-fb64-4898-baf4-bd4467ceae94.png" width="50%"></td>
  </tr>
 </table>